### PR TITLE
[xcframework] Fixed building and composing of . xcframework

### DIFF
--- a/.github/actions/xcframework-spm-ios/action.yml
+++ b/.github/actions/xcframework-spm-ios/action.yml
@@ -16,23 +16,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Build iOS
+    - name: Make xcf.sh executable
+      run: chmod +x ${{ github.action_path }}/xcf.sh
       shell: bash
-      run: |
-        pushd "${{ inputs.path }}"
-        xcodebuild build -scheme ${{ inputs.scheme }} -destination "generic/platform=iOS" -configuration Release -derivedDataPath ./build BUILD_LIBRARY_FOR_DISTRIBUTION=YES SWIFT_DISABLE_AUTOMATIC_PREVIEWS=YES SKIP_INSTALL=NO
-        popd
-    - name: Build iOS Simulator
-      shell: bash
-      run: |
-        pushd "${{ inputs.path }}"
-        xcodebuild build -scheme ${{ inputs.scheme }} -destination "generic/platform=iOS Simulator" -configuration Release -derivedDataPath ./build BUILD_LIBRARY_FOR_DISTRIBUTION=YES SWIFT_DISABLE_AUTOMATIC_PREVIEWS=YES SKIP_INSTALL=NO
-        popd
+
     - name: Create xcframework
+      run: ${{ github.action_path }}/xcf.sh
       shell: bash
-      run: |
-        chmod +x maven.sh ./.github/actions/xcframework-spm-ios/xcf.sh
-        ./.github/actions/xcframework-spm-ios/xcf.sh ${{ inputs.scheme }}
+      
     - name: Zip xcframework
       shell: bash
       run: |

--- a/.github/actions/xcframework-spm-ios/action.yml
+++ b/.github/actions/xcframework-spm-ios/action.yml
@@ -31,12 +31,9 @@ runs:
     - name: Create xcframework
       shell: bash
       run: |
-        pushd "${{ inputs.path }}"
-        xcodebuild -create-xcframework -framework ./build/Build/Products/Release-iphoneos/PackageFrameworks/${{ inputs.scheme }}.framework -framework ./build/Build/Products/Release-iphonesimulator/PackageFrameworks/${{ inputs.scheme }}.framework -output ./build/${{ inputs.framework_name }}.xcframework
-        popd
+        chmod +x maven.sh ./.github/actions/xcframework-spm-ios/xcf.sh
+        ./.github/actions/xcframework-spm-ios/xcf.sh ${{ inputs.scheme }}
     - name: Zip xcframework
       shell: bash
       run: |
-        pushd "${{ inputs.path }}/build"
         zip -r ./${{ inputs.framework_name }}.xcframework.zip ./${{ inputs.framework_name }}.xcframework
-        popd

--- a/.github/actions/xcframework-spm-ios/action.yml
+++ b/.github/actions/xcframework-spm-ios/action.yml
@@ -21,9 +21,9 @@ runs:
       shell: bash
 
     - name: Create xcframework
-      run: ${{ github.action_path }}/xcf.sh
+      run: ${{ github.action_path }}/xcf.sh ${{ inputs.scheme }}
       shell: bash
-      
+
     - name: Zip xcframework
       shell: bash
       run: |

--- a/.github/actions/xcframework-spm-ios/xcf.sh
+++ b/.github/actions/xcframework-spm-ios/xcf.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Pass scheme name as the first argument to the script
+NAME=$1
+
+# Build the scheme for all platforms that we plan to support
+for PLATFORM in "iOS" "iOS Simulator"; do
+
+    case $PLATFORM in
+    "iOS")
+    RELEASE_FOLDER="Release-iphoneos"
+    ;;
+    "iOS Simulator")
+    RELEASE_FOLDER="Release-iphonesimulator"
+    ;;
+    esac
+
+    ARCHIVE_PATH=$RELEASE_FOLDER
+
+    # Rewrite Package.swift so that it declaras dynamic libraries, since the approach does not work with static libraries
+    perl -i -p0e 's/type: .static,//g' Package.swift
+    perl -i -p0e 's/type: .dynamic,//g' Package.swift
+    perl -i -p0e 's/(library[^,]*,)/$1 type: .dynamic,/g' Package.swift
+
+    xcodebuild archive -scheme $NAME \
+            -destination "generic/platform=$PLATFORM" \
+            -archivePath $ARCHIVE_PATH \
+            -derivedDataPath ".build" \
+            SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+    FRAMEWORK_PATH="$ARCHIVE_PATH.xcarchive/Products/usr/local/lib/$NAME.framework"
+    MODULES_PATH="$FRAMEWORK_PATH/Modules"
+    mkdir -p $MODULES_PATH
+
+    BUILD_PRODUCTS_PATH=".build/Build/Intermediates.noindex/ArchiveIntermediates/$NAME/BuildProductsPath"
+    RELEASE_PATH="$BUILD_PRODUCTS_PATH/$RELEASE_FOLDER"
+    SWIFT_MODULE_PATH="$RELEASE_PATH/$NAME.swiftmodule"
+    RESOURCES_BUNDLE_PATH="$RELEASE_PATH/${NAME}_${NAME}.bundle"
+
+
+    # Copy main contents to release path 
+    FRAMEWORK_BUILD_PATH="$ARCHIVE_PATH.xcarchive/Products/Library/Frameworks/$NAME.framework"
+
+    echo "Framework build: $FRAMEWORK_BUILD_PATH"
+
+     # Copy Swift 
+    if [ -e $FRAMEWORK_BUILD_PATH ] 
+    then
+        cp -r "$FRAMEWORK_BUILD_PATH/Info.plist" $FRAMEWORK_PATH
+    else
+        # In case there are no modules, assume C/ObjC library and create module map
+        echo "Main contents $FRAMEWORK_BUILD_PATH { export * }" > $MODULES_PATH/module.modulemap
+        # TODO: Copy headers
+    fi
+
+     # Copy Swift 
+    if [ -e $FRAMEWORK_BUILD_PATH ] 
+    then
+        cp -r "$FRAMEWORK_BUILD_PATH/Tim" $FRAMEWORK_PATH
+    else
+        # In case there are no modules, assume C/ObjC library and create module map
+        echo "Main contents $FRAMEWORK_BUILD_PATH { export * }" > $MODULES_PATH/module.modulemap
+        # TODO: Copy headers
+    fi
+
+    # Copy Swift modules
+    if [ -d $SWIFT_MODULE_PATH ] 
+    then
+        cp -r $SWIFT_MODULE_PATH $MODULES_PATH
+    else
+        # In case there are no modules, assume C/ObjC library and create module map
+        echo "module $NAME { export * }" > $MODULES_PATH/module.modulemap
+        # TODO: Copy headers
+    fi
+
+    # Copy resources bundle, if exists 
+    if [ -e $RESOURCES_BUNDLE_PATH ] 
+    then
+        cp -r $RESOURCES_BUNDLE_PATH $FRAMEWORK_PATH
+    fi
+
+done
+
+xcodebuild -create-xcframework \
+-framework Release-iphoneos.xcarchive/Products/usr/local/lib/$NAME.framework \
+-framework Release-iphonesimulator.xcarchive/Products/usr/local/lib/$NAME.framework \
+-output $NAME.xcframework


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Fixed `spm` export to `.xcframework`. Due to apple's new way of building `xcframework` a more complex `sh` had to be created in order to combine all items in needed in `.xcframework` like binary file, `.modulemap` and `.bundle`. This PR contains all updates needed in order to build a complex `.xcframework`.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- New `.sh` that creates a complete `xcframework`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->