### PR TITLE
[OS] Done adding  cross os support for multiple actions

### DIFF
--- a/.github/actions/android-bump-version/action.yaml
+++ b/.github/actions/android-bump-version/action.yaml
@@ -19,8 +19,15 @@ runs:
       shell: bash
       run: |
         echo "Updating version in ${{ inputs.gradle-path }}"
-        sed -i '' "s/versionCode = .*/versionCode = ${{ inputs.version-code }}/" ${{ inputs.gradle-path }}
-        sed -i '' "s/versionName = \".*\"/versionName = \"${{ inputs.version-name }}\"/" ${{ inputs.gradle-path }}
+
+        # Determine if we're on macOS or Linux
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i '' "s/versionCode = .*/versionCode = ${{ inputs.version-code }}/" ${{ inputs.gradle-path }}
+          sed -i '' "s/versionName = \".*\"/versionName = \"${{ inputs.version-name }}\"/" ${{ inputs.gradle-path }}
+        else
+          sed -i "s/versionCode = .*/versionCode = ${{ inputs.version-code }}/" ${{ inputs.gradle-path }}
+          sed -i "s/versionName = \".*\"/versionName = \"${{ inputs.version-name }}\"/" ${{ inputs.gradle-path }}
+        fi
 
     - name: Verify Version Update
       shell: bash

--- a/.github/actions/base64-to-file/action.yaml
+++ b/.github/actions/base64-to-file/action.yaml
@@ -15,6 +15,11 @@ runs:
     - name: Generate api_key.json
       run: |
         echo "Decoding file from base64..."
-        echo "${{ inputs.base_64_data }}" | base64 -D > ${{ inputs.file_name }}
+         # Detect macOS or Linux
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          echo "${{ inputs.base_64_data }}" | base64 -D > ${{ inputs.file_name }}
+        else
+          echo "${{ inputs.base_64_data }}" | base64 -d > ${{ inputs.file_name }}
+        fi
         echo "File successfully created as ${{ inputs.file_name }}."
       shell: bash


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Done updating multiple pipelines like `android-bump-version` & `base-64-to-file` for cross os  compile.  

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `Ubuntu` support for `android-bump-version`
- `Ubuntu` support for `base-64-to-file`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->