### PR TITLE
Done added support for Xcode Workspace

### DIFF
--- a/.github/actions/fastlane-build-release/action.yml
+++ b/.github/actions/fastlane-build-release/action.yml
@@ -1,6 +1,9 @@
 name: "Build Release"
 description: "Runs build release for an iOS application"
 inputs:
+  workspace:
+    description: "Xcode Workspace"
+    required: false
   scheme:
     description: "Xcode Scheme"
     required: true
@@ -26,5 +29,5 @@ runs:
       shell: bash
     - name: Run fastlane build_release
       run: |
-        bundle exec fastlane ios build_release scheme:${{ inputs.scheme }} keychain_password:${{ inputs.keychain_password }} keychain_path:${{ inputs.keychain_path }} app_id:${{ inputs.app_id }} provisioning_profile:"${{ inputs.provisioning_profile }}"
+        bundle exec fastlane ios build_release workspace:${{ inputs.workspace }}  scheme:${{ inputs.scheme }} keychain_password:${{ inputs.keychain_password }} keychain_path:${{ inputs.keychain_path }} app_id:${{ inputs.app_id }} provisioning_profile:"${{ inputs.provisioning_profile }}"
       shell: bash

--- a/.github/actions/xcode-test/action.yml
+++ b/.github/actions/xcode-test/action.yml
@@ -1,35 +1,56 @@
 name: "Run Xcodebuild Tests with Coverage"
 description: "Run tests with xcodebuild, enable code coverage, and validate against a threshold"
+
 inputs:
   scheme:
     description: "The Xcode scheme used to build and test"
     required: true
+
+  workspace:
+    description: "The Xcode workspace to build and test"
+    required: false
+
   project:
     description: "The Xcode project to build and test"
-    required: true
+    required: false
+
   device:
     description: "The device to use for the test destination (e.g., 'iPhone 16')"
     required: true
+
   os:
     description: "The OS version to use for the test destination (e.g., '16.0')"
     required: true
+
   testPlan:
     description: "The test plan to use"
     required: true
+
   enableCodeCoverage:
     description: "YES/NO"
-    required: true
+    required: false
     default: 'YES'
 
 runs:
   using: "composite"
   steps:
     - name: Run Tests
-      run: |
-        # Run tests with coverage enabled
-        xcodebuild test -scheme "${{ inputs.scheme }}" \
-                        -project "${{ inputs.project }}" \
-                        -destination "platform=iOS Simulator,name=${{ inputs.device }},OS=${{ inputs.os }}" \
-                        -testPlan "${{ inputs.testPlan }}" \
-                        -enableCodeCoverage "${{ inputs.enableCodeCoverage }}" \
       shell: bash
+      run: |
+        # Build target flag
+        if [ -n "${{ inputs.workspace }}" ]; then
+          TARGET_FLAG="-workspace \"${{ inputs.workspace }}\""
+        elif [ -n "${{ inputs.project }}" ]; then
+          TARGET_FLAG="-project \"${{ inputs.project }}\""
+        else
+          echo "Error: Either 'workspace' or 'project' must be provided."
+          exit 1
+        fi
+
+        # Run xcodebuild with dynamic target flag
+        eval xcodebuild test \
+          $TARGET_FLAG \
+          -scheme "${{ inputs.scheme }}" \
+          -destination "platform=iOS Simulator,name=${{ inputs.device }},OS=${{ inputs.os }}" \
+          -testPlan "${{ inputs.testPlan }}" \
+          -enableCodeCoverage "${{ inputs.enableCodeCoverage }}"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

This `PR` adds support for passing `Workspace` when using either `Xcodebuild` or `fastlane` to build for `ci` or `cd`

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `fastlane-build-release`
- `xcode-test`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->