### PR TITLE
[fastlane] Done adding support for `fastlane-build-release-multiple-targets` 

### DIFF
--- a/.github/actions/fastlane-build-release-multiple-targets/action.yml
+++ b/.github/actions/fastlane-build-release-multiple-targets/action.yml
@@ -1,0 +1,30 @@
+name: "Build Release"
+description: "Runs build release for an iOS application"
+inputs:
+  workspace:
+    description: "Xcode Workspace"
+    required: false
+  scheme:
+    description: "Xcode Scheme"
+    required: true
+  keychain_password:
+    description: "Build Machine keychain pwd"
+    required: true
+  keychain_path:
+    description: "Build Machine keychain path"
+    required: true
+  provisioning_profiles:
+    description: "A sting of the following format: { com.example.app => AppProfile, com.example.app.NotificationService => NotificationProfile }"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare bundle
+      run: |
+        bundle install
+      shell: bash
+    - name: Run fastlane build_release
+      run: |
+        bundle exec fastlane ios build_release_multiple_targets workspace:${{ inputs.workspace }}  scheme:${{ inputs.scheme }} keychain_password:${{ inputs.keychain_password }} keychain_path:${{ inputs.keychain_path }} provisioning_profiles:"${{ inputs.provisioning_profiles }}"
+      shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this SDK will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/).  
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [1.1.14] - 2025-06-05
+
+### Added
+
+- Added support for running `build_release_multiple_targets` through `fastlane-build-release-multiple-targets`.
+
+## [1.1.13] - 2025-05-15
+
+### Added
+
+- Added separate actions for `xcworkspace`
+
+---
+
+## How to Use This Changelog
+
+- Update the `[Unreleased]` section during active development.
+- When you publish a new version:
+  1. Copy the contents of `[Unreleased]` into a new version section.
+  2. Replace "Unreleased" with the version number and date.
+  3. Tag the commit with that version number (e.g., `git tag 1.2.0`).


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

This `PR` adds support for running `build_release_multiple_targets ` lane through `fastlane-build-release-multiple-targets` action in order to support building and publishing an Xcode project with multiple targets. 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- added `fastlane-build-release-multiple-targets` 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->